### PR TITLE
Fix: Deferred Issuance

### DIFF
--- a/heidi-issuance/src/commonMain/kotlin/ch/ubique/heidi/issuance/credential/offer/CredentialOfferRepository.kt
+++ b/heidi-issuance/src/commonMain/kotlin/ch/ubique/heidi/issuance/credential/offer/CredentialOfferRepository.kt
@@ -33,6 +33,7 @@ class CredentialOfferRepository : HeidiIssuanceKoinComponent {
 	companion object {
 		private const val CREDENTIAL_OFFER_SCHEME = "openid-credential-offer"
 		private const val BIT_CREDENTIAL_OFFER_SCHEME = "swiyu"
+		private const val HAIP_CREDENTIAL_OFFER_SCHEME = "haip-vci"
 
 		private const val PARAM_CREDENTIAL_OFFER_URI = "credential_offer_uri"
 		private const val PARAM_CREDENTIAL_OFFER = "credential_offer"
@@ -48,7 +49,7 @@ class CredentialOfferRepository : HeidiIssuanceKoinComponent {
 		// Check if the offer string has the correct scheme
 		val parsedOfferString = Url(offerString)
 		val protocolName = parsedOfferString.protocol.name
-		if (!(protocolName == CREDENTIAL_OFFER_SCHEME || protocolName == BIT_CREDENTIAL_OFFER_SCHEME))  {
+		if (!(protocolName == CREDENTIAL_OFFER_SCHEME || protocolName == BIT_CREDENTIAL_OFFER_SCHEME || protocolName == HAIP_CREDENTIAL_OFFER_SCHEME)) {
 			return@withContext null
 		}
 

--- a/heidi-issuance/src/commonMain/kotlin/ch/ubique/heidi/issuance/metadata/data/CredentialIssuerMetadata.kt
+++ b/heidi-issuance/src/commonMain/kotlin/ch/ubique/heidi/issuance/metadata/data/CredentialIssuerMetadata.kt
@@ -2,7 +2,7 @@ package ch.ubique.heidi.issuance.metadata.data
 
 import kotlinx.serialization.Serializable
 
-@Serializable
+@Serializable(with = CredentialIssuerMetadataSerializer::class)
 sealed class CredentialIssuerMetadata {
     @Serializable
     data class Signed(

--- a/heidi-issuance/src/commonMain/kotlin/ch/ubique/heidi/issuance/metadata/data/CredentialIssuerMetadataSerializer.kt
+++ b/heidi-issuance/src/commonMain/kotlin/ch/ubique/heidi/issuance/metadata/data/CredentialIssuerMetadataSerializer.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Ubique Innovation AG
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package ch.ubique.heidi.issuance.metadata.data
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.*
+
+object CredentialIssuerMetadataSerializer : KSerializer<CredentialIssuerMetadata> {
+
+	override val descriptor = CredentialIssuerMetadataClaims.serializer().descriptor
+
+	override fun deserialize(decoder: Decoder): CredentialIssuerMetadata {
+		val jsonDecoder = decoder as JsonDecoder
+		val element = jsonDecoder.decodeJsonElement()
+		val jsonObject = element.jsonObject
+
+		val claims = jsonDecoder.json.decodeFromJsonElement(CredentialIssuerMetadataClaims.serializer(), element)
+
+		return if ("originalJwt" in jsonObject) {
+			val originalJwt = jsonObject["originalJwt"]!!.jsonPrimitive.content
+			val originalUrl = jsonObject["originalUrl"]!!.jsonPrimitive.content
+			CredentialIssuerMetadata.Signed(claims, originalJwt, originalUrl)
+		} else {
+			CredentialIssuerMetadata.Unsigned(claims)
+		}
+	}
+
+	override fun serialize(encoder: Encoder, value: CredentialIssuerMetadata) {
+		val jsonEncoder = encoder as JsonEncoder
+		val claimsElement = jsonEncoder.json.encodeToJsonElement(CredentialIssuerMetadataClaims.serializer(), value.claims)
+
+		when (value) {
+			is CredentialIssuerMetadata.Signed -> {
+				val merged = buildJsonObject {
+					claimsElement.jsonObject.forEach { (key, v) -> put(key, v) }
+					put("originalJwt", value.originalJwt)
+					put("originalUrl", value.originalUrl)
+				}
+				jsonEncoder.encodeJsonElement(merged)
+			}
+			is CredentialIssuerMetadata.Unsigned -> {
+				jsonEncoder.encodeJsonElement(claimsElement)
+			}
+		}
+	}
+}

--- a/heidi-wallet/src/commonMain/kotlin/ch/ubique/heidi/wallet/process/issuance/eaa/EaaIssuanceProcess.kt
+++ b/heidi-wallet/src/commonMain/kotlin/ch/ubique/heidi/wallet/process/issuance/eaa/EaaIssuanceProcess.kt
@@ -28,7 +28,6 @@ import ch.ubique.heidi.credentials.models.metadata.KeyMaterial
 import ch.ubique.heidi.credentials.models.metadata.Tokens
 import ch.ubique.heidi.issuance.metadata.data.CredentialConfiguration
 import ch.ubique.heidi.issuance.metadata.data.CredentialIssuerMetadata
-import ch.ubique.heidi.issuance.metadata.data.CredentialIssuerMetadataSerializer
 import ch.ubique.heidi.trust.TrustFrameworkController
 import ch.ubique.heidi.util.random.RandomGenerator
 import ch.ubique.heidi.visualization.layout.LayoutData
@@ -129,7 +128,7 @@ open class EaaIssuanceProcess(
             val identity = identityRepository.getById(identityEntity.id)!!
             val deferredCredential = deferredCredentialsRepository.getForTransactionId(transactionId)!!
             val subjects = deferredCredential.decodeMetadata()!!
-            val credentialIssuerMetadata : CredentialIssuerMetadata = json.decodeFromString(CredentialIssuerMetadataSerializer, identity.issuer.credentialIssuerMetadata)
+            val credentialIssuerMetadata : CredentialIssuerMetadata = json.decodeFromString(identity.issuer.credentialIssuerMetadata)
             trustFlowFromSaved(credentialIssuerMetadata.claims.credentialIssuer, json.decodeFromString(identity.credentialConfigurationIds!!), credentialIssuerMetadata)
 
             val oidcMetadata =

--- a/heidi-wallet/src/commonMain/kotlin/ch/ubique/heidi/wallet/process/issuance/eaa/EaaIssuanceProcess.kt
+++ b/heidi-wallet/src/commonMain/kotlin/ch/ubique/heidi/wallet/process/issuance/eaa/EaaIssuanceProcess.kt
@@ -28,6 +28,7 @@ import ch.ubique.heidi.credentials.models.metadata.KeyMaterial
 import ch.ubique.heidi.credentials.models.metadata.Tokens
 import ch.ubique.heidi.issuance.metadata.data.CredentialConfiguration
 import ch.ubique.heidi.issuance.metadata.data.CredentialIssuerMetadata
+import ch.ubique.heidi.issuance.metadata.data.CredentialIssuerMetadataSerializer
 import ch.ubique.heidi.trust.TrustFrameworkController
 import ch.ubique.heidi.util.random.RandomGenerator
 import ch.ubique.heidi.visualization.layout.LayoutData
@@ -128,7 +129,7 @@ open class EaaIssuanceProcess(
             val identity = identityRepository.getById(identityEntity.id)!!
             val deferredCredential = deferredCredentialsRepository.getForTransactionId(transactionId)!!
             val subjects = deferredCredential.decodeMetadata()!!
-            val credentialIssuerMetadata : CredentialIssuerMetadata = json.decodeFromString(identity.issuer.credentialIssuerMetadata)
+            val credentialIssuerMetadata : CredentialIssuerMetadata = json.decodeFromString(CredentialIssuerMetadataSerializer, identity.issuer.credentialIssuerMetadata)
             trustFlowFromSaved(credentialIssuerMetadata.claims.credentialIssuer, json.decodeFromString(identity.credentialConfigurationIds!!), credentialIssuerMetadata)
 
             val oidcMetadata =

--- a/heidi-wallet/src/commonMain/kotlin/ch/ubique/heidi/wallet/process/refresh/eaa/EaaRefreshProcess.kt
+++ b/heidi-wallet/src/commonMain/kotlin/ch/ubique/heidi/wallet/process/refresh/eaa/EaaRefreshProcess.kt
@@ -28,6 +28,7 @@ import ch.ubique.heidi.credentials.models.metadata.KeyMaterial
 import ch.ubique.heidi.credentials.models.metadata.Tokens
 import ch.ubique.heidi.issuance.metadata.data.AuthorizationServerMetadata
 import ch.ubique.heidi.issuance.metadata.data.CredentialIssuerMetadata
+import ch.ubique.heidi.issuance.metadata.data.CredentialIssuerMetadataSerializer
 import ch.ubique.heidi.trust.TrustFrameworkController
 import ch.ubique.heidi.util.extensions.json
 import ch.ubique.heidi.util.log.Logger
@@ -97,7 +98,7 @@ class EaaRefreshProcess(
 				identity.credentialConfigurationIds ?: "",
 			)
 			val credentialIssuerMetadata: CredentialIssuerMetadata? =
-				runCatching { json.decodeFromString<CredentialIssuerMetadata>(identity.issuer.credentialIssuerMetadata) }.getOrNull()
+				runCatching { json.decodeFromString(CredentialIssuerMetadataSerializer, identity.issuer.credentialIssuerMetadata) }.getOrNull()
 			val walletBackend = WalletBackend(EnvironmentController.getHsmBackendUrl())
 			val dpopSigner = secureHardwareAccess.getHardwareSigner(identity.tokens.dpopKeyReference)!!
 			val issuance = Oid4VciIssuance.fromMetadata(oidcMetadata, walletBackend, dpopSigner)

--- a/heidi-wallet/src/commonMain/kotlin/ch/ubique/heidi/wallet/process/refresh/eaa/EaaRefreshProcess.kt
+++ b/heidi-wallet/src/commonMain/kotlin/ch/ubique/heidi/wallet/process/refresh/eaa/EaaRefreshProcess.kt
@@ -28,7 +28,6 @@ import ch.ubique.heidi.credentials.models.metadata.KeyMaterial
 import ch.ubique.heidi.credentials.models.metadata.Tokens
 import ch.ubique.heidi.issuance.metadata.data.AuthorizationServerMetadata
 import ch.ubique.heidi.issuance.metadata.data.CredentialIssuerMetadata
-import ch.ubique.heidi.issuance.metadata.data.CredentialIssuerMetadataSerializer
 import ch.ubique.heidi.trust.TrustFrameworkController
 import ch.ubique.heidi.util.extensions.json
 import ch.ubique.heidi.util.log.Logger
@@ -97,8 +96,7 @@ class EaaRefreshProcess(
 				identity.issuer.authorizationServerMetadata,
 				identity.credentialConfigurationIds ?: "",
 			)
-			val credentialIssuerMetadata: CredentialIssuerMetadata? =
-				runCatching { json.decodeFromString(CredentialIssuerMetadataSerializer, identity.issuer.credentialIssuerMetadata) }.getOrNull()
+			val credentialIssuerMetadata : CredentialIssuerMetadata = json.decodeFromString(identity.issuer.credentialIssuerMetadata)
 			val walletBackend = WalletBackend(EnvironmentController.getHsmBackendUrl())
 			val dpopSigner = secureHardwareAccess.getHardwareSigner(identity.tokens.dpopKeyReference)!!
 			val issuance = Oid4VciIssuance.fromMetadata(oidcMetadata, walletBackend, dpopSigner)


### PR DESCRIPTION
Fixes deferred issuance of credentials.

**What broke:**
Parsing the CredentialIssuerMetadata failed during Issuance in the startDeferred() step.

**Fix:**
Add custom deserializer for sealed object checking for presence of 'originalJwt' in json object.