### PR TITLE
Feature: improve memory usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5493,7 +5493,7 @@ dependencies = [
 [[package]]
 name = "next-gen-signatures"
 version = "0.1.2"
-source = "git+https://github.com/UbiqueInnovation/sprind-next-gen-signing-service#56ed7cfa1108b96a941f314e9f955c921e660047"
+source = "git+https://github.com/UbiqueInnovation/sprind-next-gen-signing-service.git#56ed7cfa1108b96a941f314e9f955c921e660047"
 dependencies = [
  "anyhow",
  "ark-bls12-381",
@@ -6942,7 +6942,7 @@ dependencies = [
 [[package]]
 name = "rdf-util"
 version = "0.1.0"
-source = "git+https://github.com/UbiqueInnovation/sprind-next-gen-signing-service#56ed7cfa1108b96a941f314e9f955c921e660047"
+source = "git+https://github.com/UbiqueInnovation/sprind-next-gen-signing-service.git#56ed7cfa1108b96a941f314e9f955c921e660047"
 dependencies = [
  "anyhow",
  "oxrdf",
@@ -11197,7 +11197,7 @@ dependencies = [
 [[package]]
 name = "zkp-util"
 version = "0.1.0"
-source = "git+https://github.com/UbiqueInnovation/sprind-next-gen-signing-service#56ed7cfa1108b96a941f314e9f955c921e660047"
+source = "git+https://github.com/UbiqueInnovation/sprind-next-gen-signing-service.git#56ed7cfa1108b96a941f314e9f955c921e660047"
 dependencies = [
  "anyhow",
  "ark-bls12-381",

--- a/heidi-credentials/build.gradle.kts
+++ b/heidi-credentials/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 	alias(libs.plugins.kotlin.multiplatform)
 	alias(libs.plugins.android.library)
 	alias(libs.plugins.skie)
-	alias(libs.plugins.kotlin.atomicfu)
 	alias(libs.plugins.vanniktech.publish)
 	alias(libs.plugins.kotlin.serialization)
 	alias(libs.plugins.uniffi.plugin)
@@ -33,10 +32,9 @@ kotlin {
 		}
 
 		iosTarget.binaries.all {
-			freeCompilerArgs += "-Xallocator=mimalloc"
 		}
 
-		iosTarget.compilations.getByName("main") {
+		iosTarget.compilations.configureEach {
 			useRustUpLinker()
 		}
 	}

--- a/heidi-credentials/src/commonMain/kotlin/ch/ubique/heidi/credentials/models/credential/CredentialSummaryModel.kt
+++ b/heidi-credentials/src/commonMain/kotlin/ch/ubique/heidi/credentials/models/credential/CredentialSummaryModel.kt
@@ -1,0 +1,59 @@
+/* Copyright 2025 Ubique Innovation AG
+
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+ */
+
+package ch.ubique.heidi.credentials.models.credential
+
+import ch.ubique.heidi.credentials.models.metadata.KeyMaterialType
+import ch.ubique.heidi.credentials.models.oca.OcaBundleModel
+
+/**
+ * Lightweight credential representation for list/overview use-cases.
+ *
+ * Payload and OCA content are optional so overview flows can keep just the
+ * representative credential hydrated and avoid materializing every large
+ * string for every credential in the wallet.
+ */
+data class CredentialSummaryModel(
+	val id: Long,
+	val identityId: Long,
+	val name: String,
+	val metadata: CredentialMetadata,
+	val keyMaterialType: KeyMaterialType,
+	val credentialType: CredentialType,
+	val payload: String?,
+	val docType: String,
+	val ocaBundle: OcaBundleModel?,
+	val isUsed: Boolean,
+	val createdAt: Long,
+) {
+	fun toCredentialModel() = CredentialModel(
+		id = id,
+		identityId = identityId,
+		name = name,
+		metadata = metadata,
+		keyMaterialType = keyMaterialType,
+		credentialType = credentialType,
+		payload = payload.orEmpty(),
+		docType = docType,
+		ocaBundle = ocaBundle,
+		isUsed = isUsed,
+		createdAt = createdAt,
+	)
+}

--- a/heidi-crypto/build.gradle.kts
+++ b/heidi-crypto/build.gradle.kts
@@ -33,10 +33,9 @@ kotlin {
 		}
 
 		iosTarget.binaries.all {
-			freeCompilerArgs += "-Xallocator=mimalloc"
 		}
 
-		iosTarget.compilations.getByName("main") {
+		iosTarget.compilations.configureEach {
 			useRustUpLinker()
 		}
 	}

--- a/heidi-dcql/build.gradle.kts
+++ b/heidi-dcql/build.gradle.kts
@@ -33,10 +33,9 @@ kotlin {
 		}
 
 		iosTarget.binaries.all {
-			freeCompilerArgs += "-Xallocator=mimalloc"
 		}
 
-		iosTarget.compilations.getByName("main") {
+		iosTarget.compilations.configureEach {
 			useRustUpLinker()
 		}
 	}

--- a/heidi-issuance/build.gradle.kts
+++ b/heidi-issuance/build.gradle.kts
@@ -33,10 +33,9 @@ kotlin {
 		}
 
 		iosTarget.binaries.all {
-			freeCompilerArgs += "-Xallocator=mimalloc"
 		}
 
-		iosTarget.compilations.getByName("main") {
+		iosTarget.compilations.configureEach {
 			useRustUpLinker()
 		}
 	}

--- a/heidi-pdf/build.gradle.kts
+++ b/heidi-pdf/build.gradle.kts
@@ -33,10 +33,9 @@ kotlin {
 		}
 
 		iosTarget.binaries.all {
-			freeCompilerArgs += "-Xallocator=mimalloc"
 		}
 
-		iosTarget.compilations.getByName("main") {
+		iosTarget.compilations.configureEach {
 			useRustUpLinker()
 		}
 	}

--- a/heidi-presentation/build.gradle.kts
+++ b/heidi-presentation/build.gradle.kts
@@ -34,10 +34,9 @@ kotlin {
 		}
 
 		iosTarget.binaries.all {
-			freeCompilerArgs += "-Xallocator=mimalloc"
 		}
 
-		iosTarget.compilations.getByName("main") {
+		iosTarget.compilations.configureEach {
 			useRustUpLinker()
 		}
 	}

--- a/heidi-trust/build.gradle.kts
+++ b/heidi-trust/build.gradle.kts
@@ -33,10 +33,9 @@ kotlin {
 		}
 
 		iosTarget.binaries.all {
-			freeCompilerArgs += "-Xallocator=mimalloc"
 		}
 
-		iosTarget.compilations.getByName("main") {
+		iosTarget.compilations.configureEach {
 			useRustUpLinker()
 		}
 	}

--- a/heidi-util/build.gradle.kts
+++ b/heidi-util/build.gradle.kts
@@ -32,7 +32,6 @@ kotlin {
 		}
 
 		iosTarget.binaries.all {
-			freeCompilerArgs += "-Xallocator=mimalloc"
 		}
 	}
 

--- a/heidi-visualization/build.gradle.kts
+++ b/heidi-visualization/build.gradle.kts
@@ -33,7 +33,6 @@ kotlin {
 		}
 
 		iosTarget.binaries.all {
-			freeCompilerArgs += "-Xallocator=mimalloc"
 		}
 	}
 

--- a/heidi-wallet/build.gradle.kts
+++ b/heidi-wallet/build.gradle.kts
@@ -51,10 +51,9 @@ kotlin {
         }
 
         iosTarget.binaries.all {
-            freeCompilerArgs += "-Xallocator=mimalloc"
         }
 
-        iosTarget.compilations.getByName("main") {
+        iosTarget.compilations.configureEach {
             useRustUpLinker()
         }
     }

--- a/heidi-wallet/src/commonMain/kotlin/ch/ubique/heidi/wallet/credentials/ViewModelFactory.kt
+++ b/heidi-wallet/src/commonMain/kotlin/ch/ubique/heidi/wallet/credentials/ViewModelFactory.kt
@@ -94,7 +94,6 @@ class ViewModelFactory private constructor(
 		val koinModule = module {
 			factoryOf(::ViewModelFactory)
 		}
-		val inMemoryCache = mutableMapOf<String, IdentityUiModel?>()
 	}
 
 	@OptIn(ExperimentalEncodingApi::class)
@@ -198,15 +197,6 @@ class ViewModelFactory private constructor(
 	//TODO: What about EAAs? How do we represent them? We should still use something like IdentityUiModel to combine them, but something less "personal identity" based
 	fun getIdentityUiModel(identity: IdentityModel, revocationCheck: RevocationCheck? = null): IdentityUiModel? {
 		val activities = activityRepository.getActivities(identity.credentials.map { it.id })
-		inMemoryCache[identity.name]?.let {
-			if (it.credentials.size == identity.credentials.size && it.activities.size == activities.size) {
-				return it
-			}
-			return when (it) {
-				is IdentityUiModel.IdentityUiCredentialModel -> it.copy(credentials =  identity.credentials, activities = activities)
-				is IdentityUiModel.IdentityUiDeferredModel -> it.copy(credentials = identity.credentials, activities = activities)
-			}
-		}
 
 		val credential = identity.credentials.firstOrNull { it.metadata.credentialType == CredentialType.SdJwt }
 			?: identity.credentials.firstOrNull { it.metadata.credentialType == CredentialType.Mdoc }
@@ -415,9 +405,7 @@ class ViewModelFactory private constructor(
                 }
                 CredentialType.Unknown -> null
 			}
-			val newModel = uiModel?.copy(isRevoked = isRevoked)
-			inMemoryCache[identity.name] = newModel
-			return newModel
+			return uiModel?.copy(isRevoked = isRevoked)
 		} catch (e: SerializationException) {
 			Logger.error("Could not map identity", e)
 			return null

--- a/heidi-wallet/src/commonMain/kotlin/ch/ubique/heidi/wallet/credentials/ViewModelFactory.kt
+++ b/heidi-wallet/src/commonMain/kotlin/ch/ubique/heidi/wallet/credentials/ViewModelFactory.kt
@@ -51,6 +51,7 @@ import ch.ubique.heidi.visualization.oca.processing.AttributeValue
 import ch.ubique.heidi.visualization.oca.processing.OcaProcessor
 import ch.ubique.heidi.visualization.oca.processing.ProcessedAttribute
 import ch.ubique.heidi.wallet.credentials.activity.ActivityRepository
+import ch.ubique.heidi.wallet.credentials.activity.ActivityUiModel
 import ch.ubique.heidi.wallet.credentials.credential.CredentialUiModel
 import ch.ubique.heidi.wallet.credentials.format.sdjwt.getRenderMetadata
 import ch.ubique.heidi.wallet.credentials.identity.IdentityUiModel
@@ -91,6 +92,9 @@ class ViewModelFactory private constructor(
 	private val stringResourceProvider: StringResourceProvider,
 ) {
 	companion object {
+		private const val MAX_PRESENTATION_CACHE_ENTRIES = 64
+		private val inMemoryCache = LinkedHashMap<String, IdentityUiModel?>()
+
 		val koinModule = module {
 			factoryOf(::ViewModelFactory)
 		}
@@ -197,6 +201,30 @@ class ViewModelFactory private constructor(
 	//TODO: What about EAAs? How do we represent them? We should still use something like IdentityUiModel to combine them, but something less "personal identity" based
 	fun getIdentityUiModel(identity: IdentityModel, revocationCheck: RevocationCheck? = null): IdentityUiModel? {
 		val activities = activityRepository.getActivities(identity.credentials.map { it.id })
+		inMemoryCache[identity.name]?.let {
+			if (it.credentials.size == identity.credentials.size && it.activities.size == activities.size) {
+				return it
+			}
+			val updated = when (it) {
+				is IdentityUiModel.IdentityUiCredentialModel -> it.copy(
+					name = identity.name,
+					credentials = identity.credentials,
+					activities = activities,
+					frostBlob = identity.frostBlob,
+					credentialUiModel = emptyList(),
+				)
+				is IdentityUiModel.IdentityUiDeferredModel -> it.copy(
+					name = identity.name,
+					credentials = identity.credentials,
+					activities = activities,
+					frostBlob = identity.frostBlob,
+					credentialUiModel = emptyList(),
+				)
+			}
+			inMemoryCache[identity.name] = updated
+			trimPresentationCache()
+			return updated
+		}
 
 		val credential = identity.credentials.firstOrNull { it.metadata.credentialType == CredentialType.SdJwt }
 			?: identity.credentials.firstOrNull { it.metadata.credentialType == CredentialType.Mdoc }
@@ -252,7 +280,7 @@ class ViewModelFactory private constructor(
 					isRevoked = isRevoked || runBlocking { revocationCheck.check(url, index.toInt()) }
 				}
 			}
-		}
+			}
 
 		try {
 			val jsonContent = jsonContent ?: return null
@@ -402,13 +430,23 @@ class ViewModelFactory private constructor(
                         frostBlob = identity.frostBlob,
                         credentialUiModel = emptyList()
                     )
-                }
+				}
                 CredentialType.Unknown -> null
 			}
-			return uiModel?.copy(isRevoked = isRevoked)
+			val newModel = uiModel?.copy(isRevoked = isRevoked)
+			inMemoryCache[identity.name] = newModel
+			trimPresentationCache()
+			return newModel
 		} catch (e: SerializationException) {
 			Logger.error("Could not map identity", e)
 			return null
+		}
+	}
+
+	private fun trimPresentationCache() {
+		while (inMemoryCache.size > MAX_PRESENTATION_CACHE_ENTRIES) {
+			val oldestKey = inMemoryCache.entries.firstOrNull()?.key ?: break
+			inMemoryCache.remove(oldestKey)
 		}
 	}
 

--- a/heidi-wallet/src/commonMain/kotlin/ch/ubique/heidi/wallet/credentials/ViewModelFactory.kt
+++ b/heidi-wallet/src/commonMain/kotlin/ch/ubique/heidi/wallet/credentials/ViewModelFactory.kt
@@ -100,6 +100,10 @@ class ViewModelFactory private constructor(
 		}
 	}
 
+	fun pruneIdentityCache(validIdentityNames: Set<String>) {
+		inMemoryCache.keys.retainAll(validIdentityNames)
+	}
+
 	@OptIn(ExperimentalEncodingApi::class)
 	fun getCredentialViewModel(
 		credential: CredentialModel,
@@ -200,11 +204,11 @@ class ViewModelFactory private constructor(
 	//TODO: We need to also do this for mdoc only schemas
 	//TODO: What about EAAs? How do we represent them? We should still use something like IdentityUiModel to combine them, but something less "personal identity" based
 	fun getIdentityUiModel(identity: IdentityModel, revocationCheck: RevocationCheck? = null): IdentityUiModel? {
-		val activities = activityRepository.getActivities(identity.credentials.map { it.id })
 		inMemoryCache[identity.name]?.let {
-			if (it.credentials.size == identity.credentials.size && it.activities.size == activities.size) {
+			if (it.credentials.size == identity.credentials.size) {
 				return it
 			}
+			val activities = activityRepository.getActivities(identity.credentials.map { it.id })
 			val updated = when (it) {
 				is IdentityUiModel.IdentityUiCredentialModel -> it.copy(
 					name = identity.name,
@@ -225,6 +229,7 @@ class ViewModelFactory private constructor(
 			trimPresentationCache()
 			return updated
 		}
+		val activities = activityRepository.getActivities(identity.credentials.map { it.id })
 
 		val credential = identity.credentials.firstOrNull { it.metadata.credentialType == CredentialType.SdJwt }
 			?: identity.credentials.firstOrNull { it.metadata.credentialType == CredentialType.Mdoc }

--- a/heidi-wallet/src/commonMain/kotlin/ch/ubique/heidi/wallet/credentials/credential/CredentialsController.kt
+++ b/heidi-wallet/src/commonMain/kotlin/ch/ubique/heidi/wallet/credentials/credential/CredentialsController.kt
@@ -102,6 +102,7 @@ class CredentialsController private constructor(
 		identityRepository.getByActivityId(activityId)?.let { viewModelFactory.getIdentityUiModel(it, revocationCheck) }
 
 	fun getAllIdentityUiModels() = identityRepository.getAllAsFlow().map {
+		viewModelFactory.pruneIdentityCache(it.map { identity -> identity.name }.toSet())
 		it.mapNotNull { identity ->
 			viewModelFactory.getIdentityUiModel(identity, revocationCheck)
 		}
@@ -111,6 +112,7 @@ class CredentialsController private constructor(
 			viewModelFactory.getIdentityUiModel(defId)
 		}
 	}, identityRepository.getAllAsFlow().map{
+		viewModelFactory.pruneIdentityCache(it.map { identity -> identity.name }.toSet())
 		it.mapNotNull { identity ->
 			viewModelFactory.getIdentityUiModel(identity, revocationCheck)
 		}

--- a/heidi-wallet/src/commonMain/kotlin/ch/ubique/heidi/wallet/credentials/identity/IdentityRepository.kt
+++ b/heidi-wallet/src/commonMain/kotlin/ch/ubique/heidi/wallet/credentials/identity/IdentityRepository.kt
@@ -23,6 +23,7 @@ package ch.ubique.heidi.wallet.credentials.identity
 import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
 import ch.ubique.heidi.credentials.models.credential.CredentialModel
+import ch.ubique.heidi.credentials.models.credential.CredentialSummaryModel
 import ch.ubique.heidi.credentials.models.credential.CredentialType
 import ch.ubique.heidi.credentials.models.identity.IdentityModel
 import ch.ubique.heidi.credentials.models.issuer.IssuerModel
@@ -35,6 +36,7 @@ import ch.ubique.heidi.wallet.CredentialEntity
 import ch.ubique.heidi.wallet.HeidiDatabase
 import ch.ubique.heidi.wallet.IdentityEntity
 import ch.ubique.heidi.wallet.extensions.toModel
+import ch.ubique.heidi.wallet.extensions.toSummaryModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.Flow
@@ -251,32 +253,20 @@ class IdentityRepository private constructor(db: HeidiDatabase) {
 	}
 
 	private fun List<CredentialEntity>.toListFlowCredentials(): List<CredentialModel> {
+		return toListFlowCredentialSummaries().map { it.toCredentialModel() }
+	}
+
+	private fun List<CredentialEntity>.toListFlowCredentialSummaries(): List<CredentialSummaryModel> {
 		val representativeCredentialId = firstRepresentativeCredentialId()
 		return mapNotNull { credential ->
-			val model = credential.toModel { url ->
+			credential.toSummaryModel(
+				includePayload = credential.id == representativeCredentialId,
+			) { url ->
 				if (credential.id == representativeCredentialId) {
 					getOcaBundleForCredential(url)
 				} else {
 					null
 				}
-			} ?: return@mapNotNull null
-
-			if (credential.id == representativeCredentialId) {
-				model
-			} else {
-				CredentialModel(
-					model.id,
-					model.identityId,
-					model.name,
-					model.metadata,
-					model.keyMaterialType,
-					model.credentialType,
-					"",
-					model.docType,
-					null,
-					model.isUsed,
-					model.createdAt,
-				)
 			}
 		}
 	}

--- a/heidi-wallet/src/commonMain/kotlin/ch/ubique/heidi/wallet/credentials/identity/IdentityRepository.kt
+++ b/heidi-wallet/src/commonMain/kotlin/ch/ubique/heidi/wallet/credentials/identity/IdentityRepository.kt
@@ -23,6 +23,7 @@ package ch.ubique.heidi.wallet.credentials.identity
 import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
 import ch.ubique.heidi.credentials.models.credential.CredentialModel
+import ch.ubique.heidi.credentials.models.credential.CredentialType
 import ch.ubique.heidi.credentials.models.identity.IdentityModel
 import ch.ubique.heidi.credentials.models.issuer.IssuerModel
 import ch.ubique.heidi.credentials.models.metadata.Tokens
@@ -30,6 +31,7 @@ import ch.ubique.heidi.credentials.models.oca.OcaBundleModel
 
 import ch.ubique.heidi.util.extensions.toBoolean
 import ch.ubique.heidi.util.extensions.toLong
+import ch.ubique.heidi.wallet.CredentialEntity
 import ch.ubique.heidi.wallet.HeidiDatabase
 import ch.ubique.heidi.wallet.IdentityEntity
 import ch.ubique.heidi.wallet.extensions.toModel
@@ -131,6 +133,8 @@ class IdentityRepository private constructor(db: HeidiDatabase) {
 		) { identities, issuers, credentials ->
 			identities.mapNotNull { identity ->
 				issuers.firstOrNull { it.url == identity.fk_issuer_url }?.toModel()?.let { issuer ->
+					val identityCredentials = credentials.filter { it.fk_identity_id == identity.id }
+
 					IdentityModel(
 						identity.id,
 						identity.name,
@@ -140,13 +144,11 @@ class IdentityRepository private constructor(db: HeidiDatabase) {
 						identity.oidc_settings,
 						issuer,
 						identity.credential_configuration_ids,
-						credentials.filter { it.fk_identity_id == identity.id }
-							.mapNotNull { it.toModel { url -> getOcaBundleForCredential(url) } },
+						identityCredentials.toListFlowCredentials(),
 						identity.is_pid?.toBoolean() ?: false,
 					)
 				}
 			}
-
 		}
 	}
 
@@ -246,6 +248,46 @@ class IdentityRepository private constructor(db: HeidiDatabase) {
 		return credentialQueries.getByIdentity(identityId)
 			.executeAsList()
 			.mapNotNull { it.toModel { url -> getOcaBundleForCredential(url) } }
+	}
+
+	private fun List<CredentialEntity>.toListFlowCredentials(): List<CredentialModel> {
+		val representativeCredentialId = firstRepresentativeCredentialId()
+		return mapNotNull { credential ->
+			val model = credential.toModel { url ->
+				if (credential.id == representativeCredentialId) {
+					getOcaBundleForCredential(url)
+				} else {
+					null
+				}
+			} ?: return@mapNotNull null
+
+			if (credential.id == representativeCredentialId) {
+				model
+			} else {
+				CredentialModel(
+					model.id,
+					model.identityId,
+					model.name,
+					model.metadata,
+					model.keyMaterialType,
+					model.credentialType,
+					"",
+					model.docType,
+					null,
+					model.isUsed,
+					model.createdAt,
+				)
+			}
+		}
+	}
+
+	private fun List<CredentialEntity>.firstRepresentativeCredentialId(): Long? {
+		return firstOrNull { it.credential_type == CredentialType.SdJwt }?.id
+			?: firstOrNull { it.credential_type == CredentialType.Mdoc }?.id
+			?: firstOrNull { it.credential_type == CredentialType.BbsTermwise }?.id
+			?: firstOrNull { it.credential_type == CredentialType.W3C_VCDM }?.id
+			?: firstOrNull { it.credential_type == CredentialType.OpenBadge303 }?.id
+			?: firstOrNull()?.id
 	}
 
 	private fun getOcaBundleForCredential(ocaBundleUrl: String): OcaBundleModel? {

--- a/heidi-wallet/src/commonMain/kotlin/ch/ubique/heidi/wallet/extensions/EntityExtensions.kt
+++ b/heidi-wallet/src/commonMain/kotlin/ch/ubique/heidi/wallet/extensions/EntityExtensions.kt
@@ -22,6 +22,7 @@ package ch.ubique.heidi.wallet.extensions
 
 import ch.ubique.heidi.credentials.models.credential.CredentialMetadata
 import ch.ubique.heidi.credentials.models.credential.CredentialModel
+import ch.ubique.heidi.credentials.models.credential.CredentialSummaryModel
 import ch.ubique.heidi.credentials.models.credential.CredentialType
 import ch.ubique.heidi.credentials.models.issuer.IssuerModel
 import ch.ubique.heidi.credentials.models.metadata.KeyMaterialType
@@ -75,6 +76,27 @@ fun CredentialEntity.toModel(
 			this.fk_oca_bundle_url?.let { ocaBundleProvider.invoke(it) },
 			this.used.toBoolean(),
 			this.created_at
+		)
+	}
+}
+
+fun CredentialEntity.toSummaryModel(
+	includePayload: Boolean,
+	ocaBundleProvider: (String) -> OcaBundleModel?,
+): CredentialSummaryModel? {
+	return this.decodeMetadata()?.let { metadata ->
+		CredentialSummaryModel(
+			id = this.id,
+			identityId = this.fk_identity_id,
+			name = this.name,
+			metadata = metadata,
+			keyMaterialType = this.key_material_type,
+			credentialType = this.credential_type,
+			payload = this.payload.takeIf { includePayload },
+			docType = this.doc_type,
+			ocaBundle = this.fk_oca_bundle_url?.let { ocaBundleProvider.invoke(it) },
+			isUsed = this.used.toBoolean(),
+			createdAt = this.created_at,
 		)
 	}
 }

--- a/heidi-wallet/src/commonMain/kotlin/ch/ubique/heidi/wallet/process/issuance/IssuanceProcess.kt
+++ b/heidi-wallet/src/commonMain/kotlin/ch/ubique/heidi/wallet/process/issuance/IssuanceProcess.kt
@@ -68,7 +68,6 @@ abstract class IssuanceProcess(
 	private val ocaServiceController: OcaServiceController,
 	private val json: Json,
 ) {
-
 	private val credentialOfferRepository = CredentialOfferRepository()
 	private val metadataRepository = MetadataRepository()
 

--- a/heidi-wallet/src/commonMain/kotlin/ch/ubique/heidi/wallet/process/issuance/eaa/EaaIssuanceProcess.kt
+++ b/heidi-wallet/src/commonMain/kotlin/ch/ubique/heidi/wallet/process/issuance/eaa/EaaIssuanceProcess.kt
@@ -421,23 +421,22 @@ open class EaaIssuanceProcess(
                     credentialMetadatas
                 )
 
-                return if (deferredEntry == null) {
-                    EaaIssuanceProcessStep.Error("Failed to insert identity")
-                } else {
-                    val updatedIdentity = identityRepository.getById(identity.id)
-                    val card = extractDeferredCardDetails(updatedIdentity, identityName, ocaServiceController, ocaRepository)
-                    val uiModel = viewModelFactory.getIdentityUiModel(deferredEntry, card)
+	                return if (deferredEntry == null) {
+	                    EaaIssuanceProcessStep.Error("Failed to insert identity")
+	                } else {
+	                    val updatedIdentity = identityRepository.getById(identity.id)
+	                    val card = extractDeferredCardDetails(updatedIdentity, identityName, ocaServiceController, ocaRepository)
+	                    val uiModel = viewModelFactory.getIdentityUiModel(deferredEntry, card)
 
-                    if (uiModel != null) {
-                        EaaIssuanceProcessStep.CredentialOffer(trustFlow.agentInformation, uiModel)
-                    } else {
-                        EaaIssuanceProcessStep.Error("Inserted identity could not be parsed")
-                    }
-                }
-            }
+	                    if (uiModel != null) {
+	                        EaaIssuanceProcessStep.CredentialOffer(trustFlow.agentInformation, uiModel)
+	                    } else {
+	                        EaaIssuanceProcessStep.Error("Inserted identity could not be parsed")
+	                    }
+	                }
+	            }
 
-
-            val insertedCredentialIds = if (credentials.subjects().isNotEmpty()) {
+            val credentialInsertions = if (credentials.subjects().isNotEmpty()) {
                 (credentials.credentials() zip credentials.subjects()).mapNotNull { (credential, signer) ->
 
                     val credentialMetadata = if (signer.privateKeyExportable()) {
@@ -457,44 +456,51 @@ open class EaaIssuanceProcess(
                         )
                     }
 
-                    val insertedCredential =
-                        insertCredential(identity.name, credential, credentialMetadata)
-                    return@mapNotNull insertedCredential?.id
+                    buildCredentialInsertion(identity.name, credential, credentialMetadata)
                 }
             } else {
                 credentials.credentials().mapNotNull { credential ->
                     val credentialMetadata = CredentialMetadata(KeyMaterial.Local.ClaimBased(), credential.credential.asMetadataFormat())
-                    val insertedCredential =
-                        insertCredential(identity.name, credential, credentialMetadata)
-                    return@mapNotNull insertedCredential?.id
+                    buildCredentialInsertion(identity.name, credential, credentialMetadata)
                 }
+            }
+
+            val insertedCredentialIds = db.transactionWithResult {
+                val insertedIds = credentialInsertions.mapNotNull { insertion ->
+                    executeCredentialInsertion(insertion)?.id
+                }
+
+                if (insertedIds.isNotEmpty()) {
+                    activityRepository.insertIssuance(
+                        baseUrl = trustFlow.agentInformation.domain,
+                        identityJwt = trustFlow.agentInformation.identityTrust,
+                        issuanceJwt = trustFlow.agentInformation.issuanceTrust,
+                        isVerified = trustFlow.agentInformation.isVerified,
+                        isTrusted = trustFlow.agentInformation.isTrusted,
+                        identityId = identity.id,
+                        credentialId = insertedIds.last(),
+                        trustFlow.agentInformation.trustFrameworkId
+                    )
+                }
+
+                insertedIds
             }
 
 
             if (insertedCredentialIds.isNotEmpty()) {
-                activityRepository.insertIssuance(
-                    baseUrl = trustFlow.agentInformation.domain,
-                    identityJwt = trustFlow.agentInformation.identityTrust,
-                    issuanceJwt = trustFlow.agentInformation.issuanceTrust,
-                    isVerified = trustFlow.agentInformation.isVerified,
-                    isTrusted = trustFlow.agentInformation.isTrusted,
-                    identityId = identity.id,
-                    credentialId = insertedCredentialIds.last(),
-                    trustFlow.agentInformation.trustFrameworkId
-                )
 
-                val updatedIdentity = identityRepository.getById(identity.id)
-                if (updatedIdentity == null) {
-                    EaaIssuanceProcessStep.Error("Failed to insert identity")
-                } else {
-                    val uiModel = viewModelFactory.getIdentityUiModel(updatedIdentity)
-                    if (uiModel != null) {
-                        EaaIssuanceProcessStep.CredentialOffer(trustFlow.agentInformation, uiModel)
-                    } else {
-                        EaaIssuanceProcessStep.Error("Inserted identity could not be parsed")
-                    }
-                }
-            } else {
+	                val updatedIdentity = identityRepository.getById(identity.id)
+	                if (updatedIdentity == null) {
+	                    EaaIssuanceProcessStep.Error("Failed to insert identity")
+	                } else {
+	                    val uiModel = viewModelFactory.getIdentityUiModel(updatedIdentity)
+	                    if (uiModel != null) {
+	                        EaaIssuanceProcessStep.CredentialOffer(trustFlow.agentInformation, uiModel)
+	                    } else {
+	                        EaaIssuanceProcessStep.Error("Inserted identity could not be parsed")
+	                    }
+	                }
+	            } else {
                 EaaIssuanceProcessStep.Error("No credentials inserted")
             }
         } catch (e: ApiException) {


### PR DESCRIPTION
This PR reduces wallet memory churn on iOS by making the overview/list path lighter and by reducing repeated rebuilds during issuance.

On the SDK side, issuance credential inserts are now batched in a single transaction, and the identity list flow no longer hydrates full credential data for every credential in every identity. Instead, it uses a lightweight credential summary model for overview use-cases and only keeps the representative credential hydrated for list rendering. The cache handling in the wallet view-model factory was also tightened so removed identities are pruned and true cache hits avoid unnecessary activity loading.