### PR TITLE
Serialize software key IDs in JWKs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5092,6 +5092,7 @@ dependencies = [
  "ed25519-dalek 2.2.0",
  "heidi-jwt",
  "hkdf 0.12.4",
+ "josekit",
  "kapun-util-rust",
  "kapun-x509",
  "multibase",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2072,6 +2072,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "digest 0.11.3",
+ "fiat-crypto 0.3.0",
+ "rand_core 0.10.1",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "curve25519-dalek-derive"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2239,7 +2256,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.119",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2699,6 +2716,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
+dependencies = [
+ "signature 3.0.0",
+]
+
+[[package]]
 name = "ed25519-dalek"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2724,6 +2750,21 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "signature 2.2.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
+dependencies = [
+ "curve25519-dalek 5.0.0",
+ "ed25519 3.0.0",
+ "rand_core 0.10.1",
+ "sha2 0.11.0",
+ "signature 3.0.0",
  "subtle",
  "zeroize",
 ]
@@ -2962,7 +3003,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3072,6 +3113,12 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "figment"
@@ -3841,7 +3888,7 @@ dependencies = [
  "chrono",
  "heidi-x509",
  "itertools 0.14.0",
- "josekit",
+ "josekit 0.11.0 (git+https://github.com/heidiverse/josekit-rs.git)",
  "serde",
  "serde_json",
  "tracing",
@@ -3852,7 +3899,7 @@ name = "heidi-x509"
 version = "0.1.0"
 source = "git+https://github.com/heidiverse/heidi-x509.git#7ec0e8498596c0115e086e3137e58b906dea68e3"
 dependencies = [
- "josekit",
+ "josekit 0.11.0 (git+https://github.com/heidiverse/josekit-rs.git)",
  "oid-registry",
  "rsa 0.10.0-rc.18",
  "sha1",
@@ -4615,7 +4662,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4719,7 +4766,51 @@ dependencies = [
 [[package]]
 name = "josekit"
 version = "0.11.0"
-source = "git+https://github.com/heidiverse/josekit-rs.git#45cefd78b179766ece1d575c525f7032ec47cda8"
+source = "git+https://github.com/heidiverse/josekit-rs.git?branch=feature%2Fdigest-signing#0533de8da530ed93daf1e2c5630c4d854e4050ce"
+dependencies = [
+ "aes 0.8.4",
+ "aes-gcm 0.10.3",
+ "aes-kw",
+ "anyhow",
+ "base64 0.22.1",
+ "base64ct",
+ "cbc 0.1.2",
+ "crypto-bigint 0.7.5",
+ "crypto-primes",
+ "cx448",
+ "der 0.8.1",
+ "ed25519-dalek 3.0.0",
+ "flate2",
+ "getrandom 0.2.17",
+ "getrandom 0.3.4",
+ "hmac 0.13.0",
+ "k256",
+ "ml-dsa",
+ "p256 0.13.2",
+ "p384",
+ "p521",
+ "pbkdf2",
+ "pem",
+ "pkcs1 0.8.0-rc.4",
+ "pkcs8 0.11.0",
+ "rand 0.10.2",
+ "regex",
+ "rsa 0.10.0-rc.18",
+ "serde",
+ "serde_json",
+ "sha1",
+ "sha2 0.11.0",
+ "signature 3.0.0",
+ "spki 0.8.0",
+ "thiserror 2.0.19",
+ "time",
+ "x25519-dalek 2.0.1",
+]
+
+[[package]]
+name = "josekit"
+version = "0.11.0"
+source = "git+https://github.com/heidiverse/josekit-rs.git#ab67d0a2c49f69e2cb5ceb1e7f7db6afe09f34eb"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm 0.10.3",
@@ -5092,7 +5183,7 @@ dependencies = [
  "ed25519-dalek 2.2.0",
  "heidi-jwt",
  "hkdf 0.12.4",
- "josekit",
+ "josekit 0.11.0 (git+https://github.com/heidiverse/josekit-rs.git?branch=feature%2Fdigest-signing)",
  "kapun-util-rust",
  "kapun-x509",
  "multibase",
@@ -5168,7 +5259,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "heidi-jwt",
- "josekit",
+ "josekit 0.11.0 (git+https://github.com/heidiverse/josekit-rs.git?branch=feature%2Fdigest-signing)",
  "openidconnect-federation",
  "reqwest 0.11.27",
  "serde_json",
@@ -5219,7 +5310,7 @@ dependencies = [
  "hkdf 0.12.4",
  "http 0.2.12",
  "is_empty",
- "josekit",
+ "josekit 0.11.0 (git+https://github.com/heidiverse/josekit-rs.git?branch=feature%2Fdigest-signing)",
  "jsonpath_lib",
  "jsonschema",
  "kapun-credentials-rust",
@@ -5268,7 +5359,7 @@ name = "kapun-x509"
 version = "0.1.0"
 dependencies = [
  "flate2",
- "josekit",
+ "josekit 0.11.0 (git+https://github.com/heidiverse/josekit-rs.git?branch=feature%2Fdigest-signing)",
  "oid-registry",
  "pem",
  "rsa 0.10.0-rc.18",
@@ -5287,7 +5378,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "clap",
- "josekit",
+ "josekit 0.11.0 (git+https://github.com/heidiverse/josekit-rs.git?branch=feature%2Fdigest-signing)",
  "kapun-x509",
  "oid-registry",
  "pem",
@@ -6101,7 +6192,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6441,7 +6532,7 @@ dependencies = [
  "oxilangtag",
  "oxiri",
  "rand 0.8.7",
- "thiserror 2.0.19",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6450,7 +6541,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06fa874d87eae638daae9b4e3198864fe2cce68589f227c0b2cf5b62b1530516"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6463,7 +6554,7 @@ dependencies = [
  "oxilangtag",
  "oxiri",
  "oxrdf",
- "thiserror 2.0.19",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -8133,7 +8224,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9489,7 +9580,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11200,7 +11291,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ jsonschema = { version = "0.17", default-features = false }
 openidconnect-federation = { git = "https://github.com/UbiqueInnovation/openidconnect-federation.git", branch = "main" }
 rand_core = { version = "0.6.4", features = ["getrandom"] }
 ark-serialize = "0.4.2"
-josekit = { git = "https://github.com/heidiverse/josekit-rs.git", default-features = false, features = [
+josekit = { git = "https://github.com/heidiverse/josekit-rs.git", branch = "feature/digest-signing", default-features = false, features = [
     "rustcrypto",
 ] }
 zkp-util = { path = "crates/zkp-util" }

--- a/crates/kapun-x509/kapun-x509-cli/Cargo.toml
+++ b/crates/kapun-x509/kapun-x509-cli/Cargo.toml
@@ -9,7 +9,7 @@ oid-registry = "0.7.0"
 clap = { version = "4.6.1", features = ["derive"] }
 pem = "3.0.6"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-josekit = { git = "https://github.com/heidiverse/josekit-rs.git", default-features = false, features = [
+josekit = { git = "https://github.com/heidiverse/josekit-rs.git", branch = "feature/digest-signing", default-features = false, features = [
     "rustcrypto",
 ] }
 serde_json.workspace = true

--- a/crates/kapun-x509/kapun-x509/Cargo.toml
+++ b/crates/kapun-x509/kapun-x509/Cargo.toml
@@ -9,7 +9,7 @@ oid-registry = "0.7.0"
 ureq = { workspace = true, optional = true }
 whitespace-sifter = "2.3.7"
 tracing = "^0.1"
-josekit = { git = "https://github.com/heidiverse/josekit-rs.git", default-features = false, features = [
+josekit = { git = "https://github.com/heidiverse/josekit-rs.git", branch = "feature/digest-signing", default-features = false, features = [
     "rustcrypto"
 ] }
 rsa = { version = "0.10.0-rc.9", features = [

--- a/kapun-credentials/src/commonTest/kotlin/org/kapunsdk/util/json/SdJwtTests.kt
+++ b/kapun-credentials/src/commonTest/kotlin/org/kapunsdk/util/json/SdJwtTests.kt
@@ -49,17 +49,14 @@ import kotlin.test.assertFailsWith
 
 class SdJwtTests {
     @Test
-    fun generatedPublicJwkCanIncludeKeyId() {
+    fun generatedPublicJwkSerializesKeyIdWhenKeyHasKeyId() {
         val keyPair = SoftwareKeyPair()
+        val keyPairWithKeyId = SoftwareKeyPair.newWithKeyId("issuer-key")
         val bareJwk = Json.parseToJsonElement(keyPair.jwkString()).jsonObject
-        val jwkWithKeyId = Json.parseToJsonElement(keyPair.jwkStringWithKeyId("issuer-key")).jsonObject
+        val jwkWithKeyId = Json.parseToJsonElement(keyPairWithKeyId.jwkString()).jsonObject
 
         assertNull(bareJwk["kid"])
         assertEquals("issuer-key", jwkWithKeyId["kid"]?.jsonPrimitive?.content)
-        assertEquals(bareJwk["kty"], jwkWithKeyId["kty"])
-        assertEquals(bareJwk["crv"], jwkWithKeyId["crv"])
-        assertEquals(bareJwk["x"], jwkWithKeyId["x"])
-        assertEquals(bareJwk["y"], jwkWithKeyId["y"])
     }
 
     @Test

--- a/kapun-credentials/src/commonTest/kotlin/org/kapunsdk/util/json/SdJwtTests.kt
+++ b/kapun-credentials/src/commonTest/kotlin/org/kapunsdk/util/json/SdJwtTests.kt
@@ -49,6 +49,20 @@ import kotlin.test.assertFailsWith
 
 class SdJwtTests {
     @Test
+    fun generatedPublicJwkCanIncludeKeyId() {
+        val keyPair = SoftwareKeyPair()
+        val bareJwk = Json.parseToJsonElement(keyPair.jwkString()).jsonObject
+        val jwkWithKeyId = Json.parseToJsonElement(keyPair.jwkStringWithKeyId("issuer-key")).jsonObject
+
+        assertNull(bareJwk["kid"])
+        assertEquals("issuer-key", jwkWithKeyId["kid"]?.jsonPrimitive?.content)
+        assertEquals(bareJwk["kty"], jwkWithKeyId["kty"])
+        assertEquals(bareJwk["crv"], jwkWithKeyId["crv"])
+        assertEquals(bareJwk["x"], jwkWithKeyId["x"])
+        assertEquals(bareJwk["y"], jwkWithKeyId["y"])
+    }
+
+    @Test
     fun sdJwtVcHeaderUsesDcSdJwtTyp() {
         val claims: Value = Json.decodeFromString(
             """

--- a/kapun-crypto/rust/Cargo.toml
+++ b/kapun-crypto/rust/Cargo.toml
@@ -12,6 +12,7 @@ uniffi.workspace = true
 base64.workspace = true
 ciborium.workspace = true
 heidi-jwt.workspace = true
+josekit.workspace = true
 rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/kapun-crypto/rust/src/crypto/signing.rs
+++ b/kapun-crypto/rust/src/crypto/signing.rs
@@ -22,6 +22,7 @@ use crate::crypto::{SignatureCreator, base64_url_decode};
 use p256::ecdsa::{Signature, SigningKey, VerifyingKey, signature::Signer};
 use p256::{ecdsa::signature::Verifier, elliptic_curve::sec1::ToEncodedPoint};
 use rand::rngs::OsRng;
+use serde_json::Value;
 use std::sync::Arc;
 
 pub enum KeyType {
@@ -104,6 +105,13 @@ impl KeyPair {
             } => public_key.to_jwk_string(),
         }
     }
+    pub fn jwk_string_with_key_id(&self, key_id: &str) -> String {
+        let mut jwk: Value = serde_json::from_str(&self.jwk_string()).unwrap_or(Value::Null);
+        if let Some(jwk) = jwk.as_object_mut() {
+            jwk.insert("kid".to_string(), Value::String(key_id.to_string()));
+        }
+        serde_json::to_string(&jwk).unwrap_or_else(|_| self.jwk_string())
+    }
     pub fn private_jwk_string(&self) -> String {
         match self {
             Self::P256 {
@@ -176,6 +184,9 @@ impl SoftwareKeyPair {
     pub fn jwk_string(&self) -> String {
         self.0.jwk_string()
     }
+    pub fn jwk_string_with_key_id(&self, key_id: String) -> String {
+        self.0.jwk_string_with_key_id(&key_id)
+    }
     pub fn public_key_sec1(&self) -> Vec<u8> {
         self.0.public_key_sec1()
     }
@@ -202,6 +213,30 @@ impl SignatureCreator for SoftwareKeyPair {
 
     fn sign(&self, bytes: Vec<u8>) -> Result<Vec<u8>, SigningError> {
         self.0.sign_with_key(bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn public_jwk_can_include_key_id() {
+        let key_pair = SoftwareKeyPair::new();
+        let bare_jwk: Value = serde_json::from_str(&key_pair.jwk_string()).unwrap();
+        let jwk_with_key_id: Value =
+            serde_json::from_str(&key_pair.jwk_string_with_key_id("issuer-key".to_string()))
+                .unwrap();
+
+        assert_eq!(bare_jwk.get("kid"), None);
+        assert_eq!(
+            jwk_with_key_id.get("kid").and_then(Value::as_str),
+            Some("issuer-key")
+        );
+        assert_eq!(bare_jwk.get("kty"), jwk_with_key_id.get("kty"));
+        assert_eq!(bare_jwk.get("crv"), jwk_with_key_id.get("crv"));
+        assert_eq!(bare_jwk.get("x"), jwk_with_key_id.get("x"));
+        assert_eq!(bare_jwk.get("y"), jwk_with_key_id.get("y"));
     }
 }
 

--- a/kapun-crypto/rust/src/crypto/signing.rs
+++ b/kapun-crypto/rust/src/crypto/signing.rs
@@ -18,12 +18,12 @@ specific language governing permissions and limitations
 under the License.
  */
 
-use crate::crypto::{base64_url_decode, base64_url_encode, SignatureCreator};
-use josekit::jwk::Jwk;
+use crate::crypto::{base64_url_decode, SignatureCreator};
+use josekit::jwk::alg::ec::{EcCurve, EcKeyPair};
+use josekit::jwk::{Jwk, KeyPair as JoseKeyPair};
 use p256::ecdsa::{signature::Signer, Signature, SigningKey, VerifyingKey};
 use p256::{ecdsa::signature::Verifier, elliptic_curve::sec1::ToEncodedPoint};
 use rand::rngs::OsRng;
-use serde_json::Value;
 use std::sync::Arc;
 
 pub enum KeyType {
@@ -58,7 +58,8 @@ pub fn from_private_key(private_key: Vec<u8>) -> Option<KeyPair> {
 }
 pub fn from_private_jwk_string(private_key_jwk: &str) -> Option<KeyPair> {
     let jwk = Jwk::from_bytes(private_key_jwk.as_bytes()).ok()?;
-    let private_key = p256::SecretKey::from_slice(&jwk_private_key_bytes(&jwk)?).ok()?;
+    let jose_key_pair = EcKeyPair::from_jwk(&jwk).ok()?;
+    let private_key = p256::SecretKey::from_sec1_der(&jose_key_pair.to_raw_private_key()).ok()?;
     let public_key = private_key.public_key();
     let key_id = jwk
         .key_id()
@@ -125,58 +126,24 @@ impl KeyPair {
     }
 
     pub fn jwk_string(&self) -> String {
-        self.to_jose_jwk(false)
-            .map(|jwk| jwk.to_string())
+        self.to_jose_key_pair()
+            .map(|key_pair| key_pair.to_jwk_public_key().to_string())
             .unwrap_or_default()
     }
     pub fn private_jwk_string(&self) -> String {
-        self.to_jose_jwk(true)
-            .map(|jwk| jwk.to_string())
+        self.to_jose_key_pair()
+            .map(|key_pair| key_pair.to_jwk_private_key().to_string())
             .unwrap_or_default()
     }
 
-    fn to_jose_jwk(&self, private: bool) -> Option<Jwk> {
-        let Self::P256 {
-            private_key,
-            public_key,
-            key_id,
-        } = self;
-        let mut jwk = Jwk::new("EC");
-        jwk.set_parameter("crv", Some(Value::String("P-256".to_string())))
-            .ok()?;
+    fn to_jose_key_pair(&self) -> Option<EcKeyPair> {
+        let mut key_pair =
+            EcKeyPair::from_der(self.private_key_bytes(), Some(EcCurve::P256)).ok()?;
+        let Self::P256 { key_id, .. } = self;
         if let Some(key_id) = key_id {
-            jwk.set_key_id(key_id);
+            key_pair.set_key_id(Some(key_id.clone()));
         }
-
-        let public_key = public_key.to_encoded_point(false);
-        jwk.set_parameter(
-            "x",
-            Some(Value::String(base64_url_encode(public_key.x()?.to_vec()))),
-        )
-        .ok()?;
-        jwk.set_parameter(
-            "y",
-            Some(Value::String(base64_url_encode(public_key.y()?.to_vec()))),
-        )
-        .ok()?;
-        if private {
-            jwk.set_parameter(
-                "d",
-                Some(Value::String(base64_url_encode(
-                    private_key.to_bytes().to_vec(),
-                ))),
-            )
-            .ok()?;
-        }
-
-        Some(jwk)
-    }
-}
-
-fn jwk_private_key_bytes(jwk: &Jwk) -> Option<Vec<u8>> {
-    match jwk.parameter("d") {
-        Some(Value::String(value)) => Some(base64_url_decode(value.to_string())),
-        _ => None,
+        Some(key_pair)
     }
 }
 
@@ -278,6 +245,7 @@ impl SignatureCreator for SoftwareKeyPair {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::Value;
 
     #[test]
     fn public_jwk_omits_key_id_by_default() {

--- a/kapun-crypto/rust/src/crypto/signing.rs
+++ b/kapun-crypto/rust/src/crypto/signing.rs
@@ -18,8 +18,9 @@ specific language governing permissions and limitations
 under the License.
  */
 
-use crate::crypto::{SignatureCreator, base64_url_decode};
-use p256::ecdsa::{Signature, SigningKey, VerifyingKey, signature::Signer};
+use crate::crypto::{base64_url_decode, base64_url_encode, SignatureCreator};
+use josekit::jwk::Jwk;
+use p256::ecdsa::{signature::Signer, Signature, SigningKey, VerifyingKey};
 use p256::{ecdsa::signature::Verifier, elliptic_curve::sec1::ToEncodedPoint};
 use rand::rngs::OsRng;
 use serde_json::Value;
@@ -33,6 +34,7 @@ pub enum KeyPair {
     P256 {
         private_key: p256::SecretKey,
         public_key: p256::PublicKey,
+        key_id: Option<String>,
     },
 }
 
@@ -42,6 +44,7 @@ pub fn generate_keypair() -> KeyPair {
     KeyPair::P256 {
         private_key,
         public_key,
+        key_id: None,
     }
 }
 pub fn from_private_key(private_key: Vec<u8>) -> Option<KeyPair> {
@@ -50,18 +53,39 @@ pub fn from_private_key(private_key: Vec<u8>) -> Option<KeyPair> {
     Some(KeyPair::P256 {
         private_key,
         public_key,
+        key_id: None,
     })
 }
-pub fn from_private_jwk_string(private_key: &str) -> Option<KeyPair> {
-    let private_key = p256::SecretKey::from_jwk_str(private_key).ok()?;
+pub fn from_private_jwk_string(private_key_jwk: &str) -> Option<KeyPair> {
+    let jwk = Jwk::from_bytes(private_key_jwk.as_bytes()).ok()?;
+    let private_key = p256::SecretKey::from_slice(&jwk_private_key_bytes(&jwk)?).ok()?;
     let public_key = private_key.public_key();
+    let key_id = jwk
+        .key_id()
+        .filter(|kid| !kid.is_empty())
+        .map(str::to_string);
     Some(KeyPair::P256 {
         private_key,
         public_key,
+        key_id,
     })
 }
 
 impl KeyPair {
+    pub fn with_key_id(&self, key_id: String) -> Self {
+        match self {
+            Self::P256 {
+                private_key,
+                public_key,
+                ..
+            } => Self::P256 {
+                private_key: private_key.clone(),
+                public_key: public_key.clone(),
+                key_id: Some(key_id),
+            },
+        }
+    }
+
     pub fn sign_with_key(&self, message: Vec<u8>) -> Result<Vec<u8>, SigningError> {
         match self {
             Self::P256 { private_key, .. } => {
@@ -76,6 +100,7 @@ impl KeyPair {
             KeyPair::P256 {
                 private_key,
                 public_key: _,
+                key_id: _,
             } => private_key.to_bytes().to_vec(),
         }
     }
@@ -84,6 +109,7 @@ impl KeyPair {
             Self::P256 {
                 private_key: _,
                 public_key,
+                key_id: _,
             } => public_key.to_sec1_bytes().to_vec(),
         }
     }
@@ -93,32 +119,64 @@ impl KeyPair {
             Self::P256 {
                 private_key: _,
                 public_key,
+                key_id: _,
             } => public_key.to_encoded_point(true).as_bytes().to_vec(),
         }
     }
 
     pub fn jwk_string(&self) -> String {
-        match self {
-            Self::P256 {
-                private_key: _,
-                public_key,
-            } => public_key.to_jwk_string(),
-        }
-    }
-    pub fn jwk_string_with_key_id(&self, key_id: &str) -> String {
-        let mut jwk: Value = serde_json::from_str(&self.jwk_string()).unwrap_or(Value::Null);
-        if let Some(jwk) = jwk.as_object_mut() {
-            jwk.insert("kid".to_string(), Value::String(key_id.to_string()));
-        }
-        serde_json::to_string(&jwk).unwrap_or_else(|_| self.jwk_string())
+        self.to_jose_jwk(false)
+            .map(|jwk| jwk.to_string())
+            .unwrap_or_default()
     }
     pub fn private_jwk_string(&self) -> String {
-        match self {
-            Self::P256 {
-                private_key: pk,
-                public_key: _,
-            } => pk.to_jwk_string().to_string(),
+        self.to_jose_jwk(true)
+            .map(|jwk| jwk.to_string())
+            .unwrap_or_default()
+    }
+
+    fn to_jose_jwk(&self, private: bool) -> Option<Jwk> {
+        let Self::P256 {
+            private_key,
+            public_key,
+            key_id,
+        } = self;
+        let mut jwk = Jwk::new("EC");
+        jwk.set_parameter("crv", Some(Value::String("P-256".to_string())))
+            .ok()?;
+        if let Some(key_id) = key_id {
+            jwk.set_key_id(key_id);
         }
+
+        let public_key = public_key.to_encoded_point(false);
+        jwk.set_parameter(
+            "x",
+            Some(Value::String(base64_url_encode(public_key.x()?.to_vec()))),
+        )
+        .ok()?;
+        jwk.set_parameter(
+            "y",
+            Some(Value::String(base64_url_encode(public_key.y()?.to_vec()))),
+        )
+        .ok()?;
+        if private {
+            jwk.set_parameter(
+                "d",
+                Some(Value::String(base64_url_encode(
+                    private_key.to_bytes().to_vec(),
+                ))),
+            )
+            .ok()?;
+        }
+
+        Some(jwk)
+    }
+}
+
+fn jwk_private_key_bytes(jwk: &Jwk) -> Option<Vec<u8>> {
+    match jwk.parameter("d") {
+        Some(Value::String(value)) => Some(base64_url_decode(value.to_string())),
+        _ => None,
     }
 }
 
@@ -166,6 +224,10 @@ impl SoftwareKeyPair {
         Self(generate_keypair())
     }
     #[cfg_attr(feature = "uniffi", uniffi::constructor)]
+    pub fn new_with_key_id(key_id: String) -> Self {
+        Self(generate_keypair().with_key_id(key_id))
+    }
+    #[cfg_attr(feature = "uniffi", uniffi::constructor)]
     pub fn from_private_key(private_key: Vec<u8>) -> Arc<Self> {
         Arc::new(Self(
             from_private_key(private_key).unwrap_or(generate_keypair()),
@@ -183,9 +245,6 @@ impl SoftwareKeyPair {
     }
     pub fn jwk_string(&self) -> String {
         self.0.jwk_string()
-    }
-    pub fn jwk_string_with_key_id(&self, key_id: String) -> String {
-        self.0.jwk_string_with_key_id(&key_id)
     }
     pub fn public_key_sec1(&self) -> Vec<u8> {
         self.0.public_key_sec1()
@@ -221,22 +280,39 @@ mod tests {
     use super::*;
 
     #[test]
-    fn public_jwk_can_include_key_id() {
+    fn public_jwk_omits_key_id_by_default() {
         let key_pair = SoftwareKeyPair::new();
         let bare_jwk: Value = serde_json::from_str(&key_pair.jwk_string()).unwrap();
-        let jwk_with_key_id: Value =
-            serde_json::from_str(&key_pair.jwk_string_with_key_id("issuer-key".to_string()))
-                .unwrap();
 
         assert_eq!(bare_jwk.get("kid"), None);
+    }
+
+    #[test]
+    fn generated_key_with_key_id_serializes_key_id() {
+        let key_pair = SoftwareKeyPair::new_with_key_id("issuer-key".to_string());
+        let public_jwk: Value = serde_json::from_str(&key_pair.jwk_string()).unwrap();
+        let private_jwk: Value = serde_json::from_str(&key_pair.private_jwk_string()).unwrap();
+
         assert_eq!(
-            jwk_with_key_id.get("kid").and_then(Value::as_str),
+            public_jwk.get("kid").and_then(Value::as_str),
             Some("issuer-key")
         );
-        assert_eq!(bare_jwk.get("kty"), jwk_with_key_id.get("kty"));
-        assert_eq!(bare_jwk.get("crv"), jwk_with_key_id.get("crv"));
-        assert_eq!(bare_jwk.get("x"), jwk_with_key_id.get("x"));
-        assert_eq!(bare_jwk.get("y"), jwk_with_key_id.get("y"));
+        assert_eq!(
+            private_jwk.get("kid").and_then(Value::as_str),
+            Some("issuer-key")
+        );
+    }
+
+    #[test]
+    fn imported_key_with_key_id_serializes_key_id() {
+        let key_pair = SoftwareKeyPair::new_with_key_id("issuer-key".to_string());
+        let imported = SoftwareKeyPair::from_jwk_string(&key_pair.private_jwk_string());
+        let public_jwk: Value = serde_json::from_str(&imported.jwk_string()).unwrap();
+
+        assert_eq!(
+            public_jwk.get("kid").and_then(Value::as_str),
+            Some("issuer-key")
+        );
     }
 }
 

--- a/kapun-wallet/rust/src/issuance/models.rs
+++ b/kapun-wallet/rust/src/issuance/models.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
 use heidi_jwt::jwt::creator::JwtCreator;
+use heidi_jwt::JwsHeader;
 use kapun_util_rust::value::Value;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
@@ -531,7 +532,7 @@ pub struct ProofOfPossession {
 }
 
 impl ProofBuilder {
-    fn get_jws_header(&self) -> anyhow::Result<josekit::jws::JwsHeader> {
+    fn get_jws_header(&self) -> anyhow::Result<JwsHeader> {
         if self.use_did_jwk {
             use serde_json::Value as JsonValue;
             let signer = self
@@ -552,13 +553,10 @@ impl ProofBuilder {
                 "kid".to_string(),
                 JsonValue::String(format!("did:jwk:{encoded_jwk}#0")),
             );
-            josekit::jws::JwsHeader::from_map(map)
-                .or_else(|e| Err(anyhow::anyhow!("Invalid Header: {e}")))
+            JwsHeader::from_map(map).or_else(|e| Err(anyhow::anyhow!("Invalid Header: {e}")))
         } else {
-            josekit::jws::JwsHeader::from_bytes(
-                self.signer.as_ref().unwrap().signer.jwt_header().as_bytes(),
-            )
-            .or_else(|e| Err(anyhow::anyhow!("Invalid Header: {e}")))
+            JwsHeader::from_bytes(self.signer.as_ref().unwrap().signer.jwt_header().as_bytes())
+                .or_else(|e| Err(anyhow::anyhow!("Invalid Header: {e}")))
         }
     }
 

--- a/kapun-wallet/rust/src/presentation/helper.rs
+++ b/kapun-wallet/rust/src/presentation/helper.rs
@@ -24,6 +24,7 @@ use std::sync::Arc;
 
 use anyhow::{Context, anyhow};
 use heidi_jwt::jwt::creator::JwtCreator;
+use heidi_jwt::{ES256, JwsAlgorithm, JwsHeader};
 use regex::Regex;
 use reqwest::Url;
 use sdjwt::{ExternalSigner, Holder, SpecVersion};
@@ -462,7 +463,7 @@ QDVxPuyj2MJjrfJpObqhmKuzjXWhRANCAARoOdx9P/3Pr9TOyWtvRNnv9gyVEJd9
 eQitkfKWSHR/Sco6Jm/PJkO2ozsMJz5R5k7/+bXVJWll7Lo4xfKij8XI
 -----END PRIVATE KEY-----"#;
 
-    let signer = josekit::jws::ES256.signer_from_der(&pem).unwrap();
+    let signer = ES256.signer_from_der(&pem).unwrap();
 
     // let issuer = EncodingKey::from_ec_pem(pem).unwrap();
     let payload = {
@@ -478,8 +479,8 @@ eQitkfKWSHR/Sco6Jm/PJkO2ozsMJz5R5k7/+bXVJWll7Lo4xfKij8XI
         payload["cnf"]["jwk"]["alg"] = serde_json::Value::String("ES256".into());
         payload
     };
-    let mut header = josekit::jws::JwsHeader::new();
-    header.set_algorithm(josekit::jws::ES256.name());
+    let mut header = JwsHeader::new();
+    header.set_algorithm(ES256.name());
     header.set_token_type("vc+sd-jwt");
 
     payload


### PR DESCRIPTION
Adds key-id support to software-generated P-256 key pairs so `jwkString()` and
`privateJwkString()` include `kid` when the key was created or imported with one.

This also temporarily pins josekit to `feature/digest-signing`, because the
current default josekit source still panics in the EC JWK serialization path.